### PR TITLE
[fix] Parsing of aws config and credentials file (#9)

### DIFF
--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -346,6 +346,13 @@ module Miasma
             # @return [Contrib::AwsApiCore::SignatureV4]
             attr_reader :signer
           end
+          # AWS config file key remapping
+          klass.const_set(:CONFIG_FILE_REMAP,
+            Smash.new(
+              'region' => 'aws_region'
+            )
+          )
+
         end
 
         # Build new API for specified type using current provider / creds
@@ -422,13 +429,30 @@ module Miasma
           if(File.exists?(file_path))
             l_config = Smash.new.tap do |creds|
               key = nil
-              File.readlines(file_path).each do |line|
+              File.readlines(file_path).each_with_index do |line, idx|
                 line.strip!
-                if(line.start_with?('[') && line.end_with?(']'))
-                  key = line.tr('[]', '').strip
+                next if line.empty? || line.start_with?('#')
+                if(line.start_with?('['))
+                  unless(line.end_with?(']'))
+                    raise ArgumentError.new("Failed to parse aws file! (#{file_path} line #{idx + 1})")
+                  end
+                  key = line.tr('[]', '').strip.sub(/^profile /, '')
                   creds[key] = Smash.new
                 else
-                  creds[key].merge!(Smash[*line.split('=').map(&:strip)])
+                  unless(key)
+                    raise ArgumentError.new("Failed to parse aws file! (#{file_path} line #{idx + 1}) - No section defined!")
+                  end
+                  line_args = line.split('=', 2).map(&:strip)
+                  line_args.first.replace(
+                    self.class.const_get(:CONFIG_FILE_REMAP).fetch(
+                      line_args.first, line_args.first
+                    )
+                  )
+                  begin
+                    creds[key].merge!(Smash[*line_args])
+                  rescue => e
+                    raise ArgumentError.new("Failed to parse aws file! (#{file_path} line #{idx + 1})")
+                  end
                 end
               end
             end

--- a/test/specs/aws_config/config.commented
+++ b/test/specs/aws_config/config.commented
@@ -1,0 +1,4 @@
+[default]
+output=text
+# ignore=true
+region=west

--- a/test/specs/aws_config/config.default
+++ b/test/specs/aws_config/config.default
@@ -1,0 +1,3 @@
+[default]
+region=south
+output=json

--- a/test/specs/aws_config/config.malformed
+++ b/test/specs/aws_config/config.malformed
@@ -1,0 +1,5 @@
+[default]
+output=json
+
+[profile blah
+region=south

--- a/test/specs/aws_config/config.malformed.content
+++ b/test/specs/aws_config/config.malformed.content
@@ -1,0 +1,5 @@
+[default]
+region=west
+
+[profile thing1]
+region

--- a/test/specs/aws_config/config.multiple
+++ b/test/specs/aws_config/config.multiple
@@ -1,0 +1,10 @@
+[default]
+region=north
+output=json
+
+[profile thing1]
+region=south
+
+[profile thing2]
+output=text
+customized=thing

--- a/test/specs/aws_config/creds.default
+++ b/test/specs/aws_config/creds.default
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=fubar
+aws_secret_access_key=foobar

--- a/test/specs/aws_config/creds.multiple
+++ b/test/specs/aws_config/creds.multiple
@@ -1,0 +1,6 @@
+[default]
+aws_access_key_id=fubar
+aws_secret_access_key=foobar
+
+[thing2]
+aws_access_key_id=BANG

--- a/test/specs/aws_config_spec.rb
+++ b/test/specs/aws_config_spec.rb
@@ -1,0 +1,87 @@
+require 'minitest/autorun'
+require 'miasma/contrib/aws'
+
+describe Miasma::Contrib::AwsApiCore::ApiCommon do
+
+  describe 'Configuration file parsing' do
+
+    let(:klass) do
+      Class.new do
+        include Bogo::Lazy
+        include Miasma::Contrib::AwsApiCore::ApiCommon
+      end
+    end
+
+    let(:config_dir){ File.join(File.dirname(__FILE__), 'aws_config') }
+
+    it 'should load the default configuration file' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'config.default')
+      args = instance.attributes.to_smash
+      instance.custom_setup(args)
+      args[:region].must_be_nil
+      args[:aws_region].must_equal 'south'
+      args[:output].must_equal 'json'
+    end
+
+    it 'should load specific profile merged with default' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'config.multiple')
+      instance.aws_profile_name = 'thing2'
+      args = instance.attributes.to_smash
+      instance.custom_setup(args)
+      args[:region].must_be_nil
+      args[:aws_region].must_equal 'north'
+      args[:output].must_equal 'text'
+      args[:customized].must_equal 'thing'
+    end
+
+    it 'should provide useful error on malformed file' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'config.malformed')
+      instance.aws_profile_name = 'blah'
+      args = instance.attributes.to_smash
+      ->{ instance.custom_setup(args) }.must_raise ArgumentError
+    end
+
+    it 'should allow comments in config' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'config.commented')
+      args = instance.attributes.to_smash
+      instance.custom_setup(args)
+      args[:output].must_equal 'text'
+      args[:aws_region].must_equal 'west'
+      args[:ignore].must_be_nil
+    end
+
+    it 'should merge default config with default creds' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'config.default')
+      instance.aws_credentials_file = File.join(config_dir, 'creds.default')
+      args = instance.attributes.to_smash
+      instance.custom_setup(args)
+      args[:region].must_be_nil
+      args[:aws_region].must_equal 'south'
+      args[:output].must_equal 'json'
+      args[:aws_access_key_id].must_equal 'fubar'
+      args[:aws_secret_access_key].must_equal 'foobar'
+    end
+
+    it 'should load specific profile merged with default config and creds' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'config.multiple')
+      instance.aws_credentials_file = File.join(config_dir, 'creds.multiple')
+      instance.aws_profile_name = 'thing2'
+      args = instance.attributes.to_smash
+      instance.custom_setup(args)
+      args[:region].must_be_nil
+      args[:aws_region].must_equal 'north'
+      args[:output].must_equal 'text'
+      args[:customized].must_equal 'thing'
+      args[:aws_access_key_id].must_equal 'BANG'
+      args[:aws_secret_access_key].must_equal 'foobar'
+    end
+
+  end
+
+end


### PR DESCRIPTION
- Remove profile prefix from section names
- Ignore lines beginning with '#' character
- Raise helpful error exception on failed lines
