### PR TITLE
Profile .aws/credentials:source_profile support for nested profiles

### DIFF
--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -489,7 +489,6 @@ module Miasma
 
             l_profile = l_config.fetch(profile, Smash.new)
             l_profile[:aws_sts_role_arn] = l_profile.delete(:role_arn)
-            l_source_profile = Smash.new
             l_source_profile = l_config.fetch(l_profile[:source_profile], Smash.new)
 
             l_creds = l_config.fetch(

--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -488,12 +488,14 @@ module Miasma
             end
 
             l_profile = l_config.fetch(profile, Smash.new)
-            if source_profile = l_profile[:source_profile]
-              l_profile.merge!(l_config.fetch(source_profile, Smash.new))
-            end
+            l_profile[:aws_sts_role_arn] = l_profile.delete(:role_arn)
+            l_source_profile = Smash.new
+            l_source_profile = l_config.fetch(l_profile[:source_profile], Smash.new)
 
             l_creds = l_config.fetch(
               :default, Smash.new
+            ).merge(
+              l_source_profile
             ).merge(
               l_profile
             )

--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -486,12 +486,16 @@ module Miasma
                 end
               end
             end
-            l_config.fetch(
+
+            l_profile = l_config.fetch(profile, Smash.new)
+            if source_profile = l_profile[:source_profile]
+              l_profile.merge!(l_config.fetch(source_profile, Smash.new))
+            end
+
+            l_creds = l_config.fetch(
               :default, Smash.new
             ).merge(
-              l_config.fetch(
-                profile, Smash.new
-              )
+              l_profile
             )
           else
             Smash.new


### PR DESCRIPTION
.aws/credentials supports nested profiles which is double useful when you use assume_role with a centralized authenticating account

example config : 
[auth]
aws_access_key_id=
aws_secret_access_key=
region=

[delegated-sudo]
source_profile=auth
role_arn=arn:aws:iam::blahblahblah
region:
