### PR TITLE
Check for template within data store on save

### DIFF
--- a/lib/miasma/contrib/aws/orchestration.rb
+++ b/lib/miasma/contrib/aws/orchestration.rb
@@ -169,7 +169,7 @@ module Miasma
           if(stack.on_failure)
             params['OnFailure'] = stack.on_failure == 'nothing' ? 'DO_NOTHING' : stack.on_failure.upcase
           end
-          if(stack.template.empty?)
+          if(stack.data[:template].empty?)
             params['UsePreviousTemplate'] = true
           else
             params['TemplateBody'] = MultiJson.dump(stack.template)


### PR DESCRIPTION
This prevents lazy loading the template which results in always fetching
and reshipping the template, even if not required (re: #25)
