### PR TITLE
Add support for reading aws_session_token values from creds file

### DIFF
--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -358,7 +358,9 @@ module Miasma
           klass.const_set(:CONFIG_FILE_REMAP,
             Smash.new(
               'region' => 'aws_region',
-              'role_arn' => 'aws_sts_role_arn'
+              'role_arn' => 'aws_sts_role_arn',
+              'aws_security_token' => 'aws_sts_token',
+              'aws_session_token' => 'aws_sts_token'
             )
           )
           klass.const_set(:INSTANCE_PROFILE_HOST, 'http://169.254.169.254')
@@ -527,6 +529,12 @@ module Miasma
                       line_args.first, line_args.first
                     )
                   )
+                  if (line_args.last.start_with?('"'))
+                    unless (line_args.last.end_with?('"'))
+                      raise ArgumentError.new("Failed to parse aws file! (#{file_path} line #{idx + 1})")
+                    end
+                    line_args.last.replace(line_args.last[1..-2]) #strip quoted values
+                  end
                   begin
                     creds[key].merge!(Smash[*line_args])
                   rescue => e

--- a/test/specs/aws_config/creds.malformed.quoted
+++ b/test/specs/aws_config/creds.malformed.quoted
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=fubar
+aws_secret_access_key="foo=bar

--- a/test/specs/aws_config/creds.quoted
+++ b/test/specs/aws_config/creds.quoted
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id=fubar
+aws_secret_access_key="foo=bar"

--- a/test/specs/aws_config/creds.security.token
+++ b/test/specs/aws_config/creds.security.token
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id=fubar
+aws_secret_access_key=foobar
+aws_security_token="abcd=="

--- a/test/specs/aws_config/creds.session.token
+++ b/test/specs/aws_config/creds.session.token
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id=fubar
+aws_secret_access_key=foobar
+aws_session_token="abcd=="

--- a/test/specs/aws_config_spec.rb
+++ b/test/specs/aws_config_spec.rb
@@ -82,6 +82,39 @@ describe Miasma::Contrib::AwsApiCore::ApiCommon do
       args[:aws_secret_access_key].must_equal 'foobar'
     end
 
+    it 'should read quoted values and understand that the quotes are not part of the value' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'creds.quoted')
+      args = instance.attributes.to_smash
+      instance.custom_setup(args)
+      args[:aws_secret_access_key].must_equal 'foo=bar'
+    end
+
+    it 'should read aws_security_token from the file as aws_sts_token' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'creds.security.token')
+      args = instance.attributes.to_smash
+      instance.custom_setup(args)
+      args[:aws_sts_token].must_equal 'abcd=='
+    end
+
+    it 'should read aws_session_token from the file as aws_sts_token' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'creds.session.token')
+      args = instance.attributes.to_smash
+      instance.custom_setup(args)
+      args[:aws_sts_token].must_equal 'abcd=='
+    end
+
+    it 'should provide useful error on malformed quotes file' do
+      instance = klass.new
+      instance.aws_config_file = File.join(config_dir, 'creds.malformed.quoted')
+      args = instance.attributes.to_smash
+      ->{ instance.custom_setup(args) }.must_raise ArgumentError
+    end
+
+
+
   end
 
 end


### PR DESCRIPTION
This addresses #30 

I added some specs for the new credentials file-reading features, though I wasn't able to get all the other specs to pass. (They seemed to be failing already when I ran them with no changes.)

I apologize for PRing to the master branch - just read that now.
