### PR TITLE
Do not provide profile information to STS instance.

### DIFF
--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -502,7 +502,6 @@ module Miasma
               :aws_region => creds.fetch(:aws_sts_region, 'us-east-1'),
               :aws_credentials_file => creds.fetch(:aws_credentials_file, aws_credentials_file),
               :aws_config_file => creds.fetch(:aws_config_file, aws_config_file),
-              :aws_profile_name => creds[:aws_profile_name],
               :aws_host => creds[:aws_sts_host],
               :aws_sts_token => creds[:aws_sts_session_token]
             )


### PR DESCRIPTION
Providing profile information to the STS instance will result in death
loop due to each instance attempting to create a new STS instance. Fixes
