### PR TITLE
adding functionality for ecs task role

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - 'test/**/**/*'
     - 'bin/*'
 
-Style/SpaceAfterControlKeyword:
+Style/SpaceAroundKeyword:
   Enabled: false
 Style/IfUnlessModifier:
   Enabled: false

--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -467,11 +467,14 @@ module Miasma
         # @param creds [Hash]
         # @return [TrueClass]
         def load_ecs_credentials!(creds)
+          # As per docs ECS_TASK_PROFILE_PATH is defined as
+          # /credential_provider_version/credentials?id=task_UUID 
+          # where AWS fills in the version and UUID.
           data = HTTP.get(
             [
               self.class.const_get(:ECS_TASK_PROFILE_HOST),
               self.class.const_get(:ECS_TASK_PROFILE_PATH)
-            ].join('/')
+            ].join('')
           ).body
           unless(data.is_a?(Hash))
             begin


### PR DESCRIPTION
ECS allows tasks to hit a different metadata service and each task can on a parent host can operate using different profile roles.

http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html
