### PR TITLE
NoMethodError fix for load_ecs_credentials!

### DIFF
--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -436,7 +436,7 @@ module Miasma
           if(creds[:aws_iam_instance_profile])
             self.class.const_get(:ECS_TASK_PROFILE_PATH).nil? ?
               load_instance_credentials!(creds) :
-              load_ecs_credentials(creds)
+              load_ecs_credentials!(creds)
           end
           true
         end


### PR DESCRIPTION
Sfn is failing to run with an ecs task role configuration due to the following exception caused by method name mismatch. This should address that.

```ERROR: Miasma::Error: Failed to load requested API type :Orchestration (Reason: NoMethodError - undefined method `load_ecs_credentials' for #<Miasma::Models::Orchestration::Aws:0x00000002134d20>
Did you mean?  load_ecs_credentials!)```

Pull requesting into master since this is a one commit bug fix.

Thank you