### PR TITLE
Update STS to refresh token within 10 minutes of expiry

### DIFF
--- a/lib/miasma/contrib/aws.rb
+++ b/lib/miasma/contrib/aws.rb
@@ -395,6 +395,8 @@ module Miasma
           klass.const_set(
             :ECS_TASK_PROFILE_PATH, ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
           )
+          # Reload sts tokens if expiry is within the next 10 minutes
+          klass.const_set(:STS_TOKEN_EXPIRY_BUFFER, 600)
         end
 
         # Build new API for specified type using current provider / creds
@@ -799,7 +801,7 @@ module Miasma
         def sts_assume_role_update_required?(args = {})
           if args.fetch(:aws_sts_role_arn, attributes[:aws_sts_role_arn])
             expiry = args.fetch(:aws_sts_token_expires, attributes[:aws_sts_token_expires])
-            expiry.nil? || expiry - 15 <= Time.now
+            expiry.nil? || expiry - self.class.const_get(:STS_TOKEN_EXPIRY_BUFFER) <= Time.now
           else
             false
           end
@@ -814,7 +816,7 @@ module Miasma
               :aws_sts_session_token_expires,
               attributes[:aws_sts_session_token_expires]
             )
-            expiry.nil? || expiry - 15 <= Time.now
+            expiry.nil? || expiry - self.class.const_get(:STS_TOKEN_EXPIRY_BUFFER) <= Time.now
           else
             false
           end

--- a/test/rspecs/miasma/contrib/aws_rspec.rb
+++ b/test/rspecs/miasma/contrib/aws_rspec.rb
@@ -12,7 +12,7 @@ describe Miasma::Contrib::AwsApiCore::ApiCommon do
 
   describe "#sts_assume_role_update_required?" do
     let(:aws_sts_role_arn) { "ARN" }
-    let(:aws_sts_token_expires) { Time.now + 60 }
+    let(:aws_sts_token_expires) { Time.now + 700 }
 
     context "with role arn set in attributes" do
       before do
@@ -52,7 +52,7 @@ describe Miasma::Contrib::AwsApiCore::ApiCommon do
 
   describe "#sts_mfa_session_update_required?" do
     let(:aws_sts_session_token_code) { "CODE" }
-    let(:aws_sts_session_token_expires) { Time.now + 60 }
+    let(:aws_sts_session_token_expires) { Time.now + 700 }
 
     context "with role arn set in attributes" do
       before do


### PR DESCRIPTION
Update token refresh expiry time, update tests around expiry, and move expiry buffer into constant.

Fixes #55 