### PR TITLE
Allow specify DurationSeconds for assume_role

### DIFF
--- a/lib/miasma-aws/api/sts.rb
+++ b/lib/miasma-aws/api/sts.rb
@@ -54,6 +54,7 @@ module Miasma
               params["RoleArn"] = role_arn
               params["RoleSessionName"] = args[:session_name] || SecureRandom.uuid.tr("-", "")
               params["ExternalId"] = args[:external_id] if args[:external_id]
+              params["DurationSeconds"] = args[:duration] if args[:duration]
             end
             result = request(
               :path => "/",


### PR DESCRIPTION
Our SFN updates takes > 1 hour, we need to extend DurationSeconds. This PR will allow user to provide custom DurationSeconds.

[AWS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)